### PR TITLE
feature: #4 - 멀티 쓰레드를 이용한 카카오 알람 전송

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,11 +22,11 @@ repositories {
 }
 
 dependencies {
-    // Batch
+    // spring
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-batch'
-
-    // JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'
@@ -39,6 +39,9 @@ dependencies {
     // mapstruct
     implementation 'org.mapstruct:mapstruct:1.5.2.Final'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.2.Final'
+
+    // hibernate-types
+    implementation 'com.vladmihalcea:hibernate-types-52:2.19.2'
 
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/db/initdb.d/create_table.sql
+++ b/db/initdb.d/create_table.sql
@@ -69,11 +69,23 @@ CREATE TABLE `user` (
 ) ENGINE = InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='사용자';
 
 CREATE TABLE `user_group_mapping` (
-    `user_group_id`   varchar(20) NOT NULL                            COMMENT '사용자 ID',
+    `user_group_id`   varchar(20) NOT NULL                           COMMENT '사용자 그룹 ID',
+    `user_id`         varchar(20) NOT NULL                           COMMENT '사용자 ID',
     `user_group_name` varchar(50) NOT NULL                           COMMENT '사용자 그룹 이름',
     `description`     varchar(50) NOT NULL                           COMMENT '설명',
     `created_at`      timestamp   NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성 일시',
     `modified_at`      timestamp            DEFAULT NULL              COMMENT '수정 일시',
     PRIMARY KEY (`user_group_id`, `user_id`)
 ) ENGINE = InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='사용자 그룹 매핑';
-)
+
+CREATE TABLE `notification` (
+    `notification_seq` int           NOT NULL AUTO_INCREMENT            COMMENT '알람 순번',
+    `uuid`            varchar(20)   NOT NULL                           COMMENT '사용자 uuid(카카오톡)',
+    `event`           varchar(10)   NOT NULL                           COMMENT '이벤트',
+    `text`            varchar(1000) NOT NULL                           COMMENT '알람 내용',
+    `sent`            tinyint(1)    NOT NULL DEFAULT(0)                COMMENT '발송 여부',
+    `sent_at`         timestamp              DEFAULT NULL              COMMENT '발송 일시',
+    `created_at`      timestamp     NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성 일시',
+    `modified_at`      timestamp              DEFAULT NULL              COMMENT '수정 일시',
+    PRIMARY KEY (`notification_seq`)
+) ENGINE = InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='알람';

--- a/src/main/java/com/example/pass/adapter/message/KakaoTalkMessageAdapter.java
+++ b/src/main/java/com/example/pass/adapter/message/KakaoTalkMessageAdapter.java
@@ -1,0 +1,37 @@
+package com.example.pass.adapter.message;
+
+import com.example.pass.config.KakaoTalkMessageConfig;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Service
+public class  KakaoTalkMessageAdapter {
+
+    private final WebClient webClient;
+
+    public KakaoTalkMessageAdapter(KakaoTalkMessageConfig config) {
+        webClient = WebClient.builder()
+                .baseUrl(config.getHost())
+                .defaultHeaders(header -> {
+                    header.setBearerAuth(config.getToken());
+                    header.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+                })
+                .build();
+    }
+
+    public boolean sendKakaoTalkMessage(final String uuid, final String text) {
+        KakaoTalkMessageResponse response = webClient.post().uri("/vi/api/talk/friends/message/default/send")
+                .body(BodyInserters.fromValue(new KakaoTalkMessageRequest(uuid, text )))
+                .retrieve()
+                .bodyToMono(KakaoTalkMessageResponse.class)
+                .block();
+
+        if (response == null || response.getSuccessfulReceiverUuids() == null) {
+            return false;
+        }
+
+        return response.getSuccessfulReceiverUuids().size() > 0;
+    }
+}

--- a/src/main/java/com/example/pass/adapter/message/KakaoTalkMessageRequest.java
+++ b/src/main/java/com/example/pass/adapter/message/KakaoTalkMessageRequest.java
@@ -1,0 +1,52 @@
+package com.example.pass.adapter.message;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.Collections;
+import java.util.List;
+
+@Getter
+@Setter
+@ToString
+public class KakaoTalkMessageRequest {
+    @JsonProperty("template_object")
+    private TemplateObject templateObject;
+
+    @JsonProperty("receiver_uuids")
+    private List<String> receiverUuids;
+
+    @Getter
+    @Setter
+    @ToString
+    public static class TemplateObject {
+        @JsonProperty("obejct_type")
+        private String objectType;
+        private String text;
+        private Link link;
+
+        @Getter
+        @Setter
+        @ToString
+        public static class Link {
+            @JsonProperty("web_url")
+            private String webUrl;
+        }
+    }
+
+    public KakaoTalkMessageRequest(String uuid, String text) {
+        List<String> receiverUuids = Collections.singletonList(uuid);
+
+        TemplateObject.Link link = new TemplateObject.Link();
+        TemplateObject templateObject = new TemplateObject();
+
+        templateObject.setObjectType("text");
+        templateObject.setText(text);
+        templateObject.setLink(link);
+
+        this.receiverUuids = receiverUuids;
+        this.templateObject = templateObject;
+    }
+}

--- a/src/main/java/com/example/pass/adapter/message/KakaoTalkMessageResponse.java
+++ b/src/main/java/com/example/pass/adapter/message/KakaoTalkMessageResponse.java
@@ -1,0 +1,16 @@
+package com.example.pass.adapter.message;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+@Setter
+@ToString
+public class KakaoTalkMessageResponse {
+    @JsonProperty("successful_receiver_uuids")
+    private List<String> successfulReceiverUuids;
+}

--- a/src/main/java/com/example/pass/config/KakaoTalkMessageConfig.java
+++ b/src/main/java/com/example/pass/config/KakaoTalkMessageConfig.java
@@ -1,0 +1,15 @@
+package com.example.pass.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "kakaotalk")
+public class KakaoTalkMessageConfig {
+    private String host;
+    private String token;
+}

--- a/src/main/java/com/example/pass/job/notification/SendNotificationBeforeClassJobConfig.java
+++ b/src/main/java/com/example/pass/job/notification/SendNotificationBeforeClassJobConfig.java
@@ -1,0 +1,116 @@
+package com.example.pass.job.notification;
+
+import com.example.pass.repository.booking.BookingEntity;
+import com.example.pass.repository.notification.NotificationEntity;
+import com.example.pass.repository.notification.NotificationEvent;
+import com.example.pass.repository.notification.NotificationModelMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.database.JpaCursorItemReader;
+import org.springframework.batch.item.database.JpaItemWriter;
+import org.springframework.batch.item.database.JpaPagingItemReader;
+import org.springframework.batch.item.database.builder.JpaCursorItemReaderBuilder;
+import org.springframework.batch.item.database.builder.JpaItemWriterBuilder;
+import org.springframework.batch.item.database.builder.JpaPagingItemReaderBuilder;
+import org.springframework.batch.item.support.SynchronizedItemStreamReader;
+import org.springframework.batch.item.support.builder.SynchronizedItemStreamReaderBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+
+import javax.persistence.EntityManagerFactory;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Configuration
+public class SendNotificationBeforeClassJobConfig {
+    private final int CHUNK_SIZE = 10;
+
+    private final JobBuilderFactory jobBuilderFactory;
+    private final StepBuilderFactory stepBuilderFactory;
+    private final EntityManagerFactory entityManagerFactory;
+    private final SendNotificationItemWriter sendNotificationItemWriter;
+
+    @Bean
+    public Job sendNotificationBeforeClassJob() {
+        return this.jobBuilderFactory.get("sendNotificationBeforeClassJob")
+                .start(addNotificationStep())
+                .next(sendNotificationStep())
+                .build();
+    }
+
+    @Bean
+    public Step addNotificationStep() {
+        return this.stepBuilderFactory.get("addNotificationStep")
+                .<BookingEntity, NotificationEntity>chunk(CHUNK_SIZE)
+                .reader(addNotificationItemReader())
+                .processor(addNotificationItemProcessor())
+                .writer(addNotificationItemWriter())
+                .build();
+    }
+
+
+    /**
+     * JpaPagingItemReader : JPA에서 사용하는 페이징 기법
+     * 쿼리 당 PageSize만큼 가져오며 다른 PagingItemReader와 마찬가지로 Thread-safe
+     */
+    @Bean
+    public JpaPagingItemReader<BookingEntity> addNotificationItemReader() {
+        // 상태(status)가 준비중이며, 시작일시(startedAt)이 10분 후 시작하는 예약이 알람 대
+        return new JpaPagingItemReaderBuilder<BookingEntity>()
+                .name("addNotificationItemReader")
+                .entityManagerFactory(entityManagerFactory)
+                .pageSize(CHUNK_SIZE)
+                .queryString("SELECT b " +
+                             "FROM BookingEntity b " +
+                             "JOIN FETCH b.userEntity " +
+                             "WHERE b.status = :status " +
+                             "  AND b.startedAt <= :startedAt " +
+                             "ORDER BY b.bookingSeq")
+                .build();
+    }
+
+    @Bean
+    public ItemProcessor<BookingEntity, NotificationEntity> addNotificationItemProcessor() {
+        return bookingEntity -> NotificationModelMapper.INSTANCE.toNotificationEntity(bookingEntity, NotificationEvent.BEFORE_CLASS);
+    }
+
+    @Bean
+    public JpaItemWriter<NotificationEntity> addNotificationItemWriter() {
+        return new JpaItemWriterBuilder<NotificationEntity>()
+                .entityManagerFactory(entityManagerFactory)
+                .build();
+    }
+
+    public Step sendNotificationStep() {
+        return this.stepBuilderFactory.get("sendNotificationStep")
+                .<NotificationEntity, NotificationEntity>chunk(CHUNK_SIZE)
+                .reader(sendNotificationItemReader())
+                .writer(sendNotificationItemWriter)
+                .taskExecutor(new SimpleAsyncTaskExecutor())
+                .build();
+    }
+
+    @Bean
+    public SynchronizedItemStreamReader<NotificationEntity> sendNotificationItemReader() {
+        // 이벤트(event)가 수업 전이며, 발송 여부(sent)가 미발송인 알람이 조회 대상
+        JpaCursorItemReader<NotificationEntity> itemReader = new JpaCursorItemReaderBuilder<NotificationEntity>()
+                .name("sendNotificationItemReader")
+                .entityManagerFactory(entityManagerFactory)
+                .queryString("SELECT n" +
+                             "FROM NotificationEntity n " +
+                             "WHERE n.event = :event " +
+                             "  AND n.sent = :sent")
+                .parameterValues(Map.of("event", NotificationEvent.BEFORE_CLASS, "sent", false))
+                .build();
+
+        return new SynchronizedItemStreamReaderBuilder<NotificationEntity>()
+                .delegate(itemReader)
+                .build();
+    }
+}

--- a/src/main/java/com/example/pass/job/notification/SendNotificationItemWriter.java
+++ b/src/main/java/com/example/pass/job/notification/SendNotificationItemWriter.java
@@ -1,0 +1,41 @@
+package com.example.pass.job.notification;
+
+import com.example.pass.adapter.message.KakaoTalkMessageAdapter;
+import com.example.pass.repository.notification.NotificationEntity;
+import com.example.pass.repository.notification.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class SendNotificationItemWriter implements ItemWriter<NotificationEntity> {
+    private final NotificationRepository notificationRepository;
+    private KakaoTalkMessageAdapter kakaoTalkMessageAdapter;
+
+    @Override
+    public void write(List<? extends NotificationEntity> notificationEntities) throws Exception {
+        int count = 0;
+
+        for (NotificationEntity notificationEntity : notificationEntities) {
+            boolean successful = kakaoTalkMessageAdapter.sendKakaoTalkMessage(notificationEntity.getUuid(), notificationEntity.getText());
+
+            if (successful) {
+                notificationEntity.setSent(true);
+                notificationEntity.setSentAt(LocalDateTime.now());
+
+                notificationRepository.save(notificationEntity);
+
+                count++;
+            }
+        }
+
+        log.info("SendNotificationItemWriter = write : 수업 전 알람 {}/{} 건 전송 성공", count, notificationEntities.size());
+    }
+
+}

--- a/src/main/java/com/example/pass/repository/notification/NotificationEntity.java
+++ b/src/main/java/com/example/pass/repository/notification/NotificationEntity.java
@@ -1,0 +1,30 @@
+package com.example.pass.repository.notification;
+
+import com.example.pass.repository.BaseEntity;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@ToString
+@Entity
+@Table(name = "notification")
+public class NotificationEntity extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer notificationSeq;
+
+    private String uuid;
+
+    private NotificationEvent event;
+
+    private String text;
+
+    private boolean sent;
+
+    private LocalDateTime sentAt;
+}

--- a/src/main/java/com/example/pass/repository/notification/NotificationEvent.java
+++ b/src/main/java/com/example/pass/repository/notification/NotificationEvent.java
@@ -1,0 +1,6 @@
+package com.example.pass.repository.notification;
+
+public enum NotificationEvent {
+    BEFORE_CLASS,
+    ;
+}

--- a/src/main/java/com/example/pass/repository/notification/NotificationModelMapper.java
+++ b/src/main/java/com/example/pass/repository/notification/NotificationModelMapper.java
@@ -1,0 +1,27 @@
+package com.example.pass.repository.notification;
+
+import com.example.pass.util.LocalDateTimeUtils;
+import com.example.pass.repository.booking.BookingEntity;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.factory.Mappers;
+
+import java.time.LocalDateTime;
+
+@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface NotificationModelMapper {
+    NotificationModelMapper INSTANCE = Mappers.getMapper(NotificationModelMapper.class);
+
+    // 필드명이 같지 않거나 custom하게 매핑해주기 위해서는 @Mapping을 추가
+    @Mapping(target = "uuid", source = "bookingEntity.userEntity.uuid")
+    @Mapping(target = "text", source = "bookingEntity.startedAt", qualifiedByName = "text")
+    NotificationEntity toNotificationEntity(BookingEntity bookingEntity, NotificationEvent notificationEvent);
+
+    // 알람을 보낼 메시지 생성
+    @Named("text")
+    default String text(LocalDateTime startedAt) {
+        return String.format("안녕하세요. %s 수업이 시작됩니다. 수업 전 출석체크 부탁드립니다. \uD83D\uDE0A", LocalDateTimeUtils.format(startedAt));
+    }
+}

--- a/src/main/java/com/example/pass/repository/notification/NotificationRepository.java
+++ b/src/main/java/com/example/pass/repository/notification/NotificationRepository.java
@@ -1,0 +1,6 @@
+package com.example.pass.repository.notification;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<NotificationEntity, Integer> {
+}

--- a/src/main/java/com/example/pass/repository/user/UserEntity.java
+++ b/src/main/java/com/example/pass/repository/user/UserEntity.java
@@ -1,17 +1,22 @@
 package com.example.pass.repository.user;
 
 import com.example.pass.repository.BaseEntity;
+import com.vladmihalcea.hibernate.type.json.JsonType;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
 
 import javax.persistence.*;
+import java.util.Map;
 
 @Getter
 @Setter
 @ToString
 @Entity
 @Table(name = "user")
+@TypeDef(name = "json", typeClass = JsonType.class)
 public class UserEntity extends BaseEntity {
     @Id
     private String userId;
@@ -23,5 +28,16 @@ public class UserEntity extends BaseEntity {
 
     private String phone;
 
-    private String meta;
+    @Type(type = "json")
+    private Map<String, Object> meta;
+
+    public String getUuid() {
+        String uuid = null;
+
+        if (meta.containsKey("uuid")) {
+            uuid = String.valueOf(meta.get("uuid"));
+        }
+
+        return uuid;
+    }
 }

--- a/src/main/java/com/example/pass/util/LocalDateTimeUtils.java
+++ b/src/main/java/com/example/pass/util/LocalDateTimeUtils.java
@@ -1,0 +1,26 @@
+package com.example.pass.util;
+
+import com.vladmihalcea.hibernate.util.StringUtils;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class LocalDateTimeUtils {
+    public static final DateTimeFormatter YYYY_MM_DD_HH_MM = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
+    public static String format(final LocalDateTime localDateTime) {
+        return localDateTime.format(YYYY_MM_DD_HH_MM);
+    }
+
+    public static String format(final LocalDateTime localDateTime, DateTimeFormatter formatter) {
+        return localDateTime.format(formatter);
+    }
+
+    public static LocalDateTime parse(final String localDateTimeString) {
+        if (StringUtils.isBlank(localDateTimeString)) {
+            return null;
+        }
+
+        return LocalDateTime.parse(localDateTimeString, YYYY_MM_DD_HH_MM);
+    }
+}


### PR DESCRIPTION
- 멀티 쓰레드를 이용하여 카카오톡 알람 전송을 할 수 있도록 배치 기능 구현
  - JpaCursorItemReader의 경우 Thread-safe하지 않음
  - 멀티 쓰레드를 통해 비동기로 구현할 때는 ItemWriter를 SynchronizedItemStreamReader를 통해 구현
  - 상기 클래스를 이용할 경우 동기로 ItemReader를 진행한 수 Writer를 비동기로 진행
- 카카오 OpenApi를 사용하도록 강의에 사용되었지만 무의미 - 테스트 X