### PR TITLE
feature: #5 - 멀티쓰레드를 이용한 이용권 만료 상태 변경 기능구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     // spring
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-batch'
+    implementation 'org.springframework.batch:spring-batch-integration'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 

--- a/src/main/java/com/example/pass/job/pass/UserPassesJobConfig.java
+++ b/src/main/java/com/example/pass/job/pass/UserPassesJobConfig.java
@@ -1,0 +1,112 @@
+package com.example.pass.job.pass;
+
+import com.example.pass.repository.booking.BookingEntity;
+import com.example.pass.repository.booking.BookingRepository;
+import com.example.pass.repository.booking.BookingStatus;
+import com.example.pass.repository.pass.PassEntity;
+import com.example.pass.repository.pass.PassRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.batch.integration.async.AsyncItemProcessor;
+import org.springframework.batch.integration.async.AsyncItemWriter;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.database.JpaCursorItemReader;
+import org.springframework.batch.item.database.builder.JpaCursorItemReaderBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+
+import javax.persistence.EntityManagerFactory;
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.concurrent.Future;
+
+@RequiredArgsConstructor
+@Configuration
+public class UserPassesJobConfig {
+
+    private final int CHUNK_SIZE = 5;
+    private final JobBuilderFactory jobBuilderFactory;
+    private final StepBuilderFactory stepBuilderFactory;
+    private final EntityManagerFactory entityManagerFactory;
+    private final PassRepository passRepository;
+    private final BookingRepository bookingRepository;
+
+    @Bean
+    public Job usePassesJob() {
+        return this.jobBuilderFactory.get("usePassesJob")
+                .start(usePassesStep())
+                .build();
+    }
+
+    @Bean
+    public Step usePassesStep() {
+        return this.stepBuilderFactory.get("usePassesStep")
+                .<BookingEntity, Future<BookingEntity>>chunk(CHUNK_SIZE)
+                .reader(userPassesItemReader())
+                .processor(userPassesAsyncItemProcessor())
+                .writer(usePassesAsyncItemWriter())
+                .build();
+    }
+
+    @Bean
+    public JpaCursorItemReader<BookingEntity> userPassesItemReader() {
+        return new JpaCursorItemReaderBuilder<BookingEntity>()
+                .name("userPassesItemReader")
+                .entityManagerFactory(entityManagerFactory)
+                .queryString("select b from BookingEntity b join fetch b.passEntity where b.status = :status and b.usedPass = false and b.endedAt < :endedAt")
+                .parameterValues(Map.of("status", BookingStatus.COMPLETED, "endedAt", LocalDateTime.now()))
+                .build();
+    }
+
+    @Bean
+    public AsyncItemProcessor<BookingEntity, BookingEntity> userPassesAsyncItemProcessor() {
+        AsyncItemProcessor<BookingEntity, BookingEntity> asyncItemProcessor = new AsyncItemProcessor<>();
+
+        asyncItemProcessor.setDelegate(userPassesItemProcessor());
+        asyncItemProcessor.setTaskExecutor(new SimpleAsyncTaskExecutor());
+
+        return asyncItemProcessor;
+    }
+
+    @Bean
+    public ItemProcessor<BookingEntity, BookingEntity> userPassesItemProcessor() {
+        return bookingEntity -> {
+            PassEntity passEntity = bookingEntity.getPassEntity();
+
+            passEntity.setRemainingCount(passEntity.getRemainingCount() - 1);
+            bookingEntity.setPassEntity(passEntity);
+
+            bookingEntity.setUsedPass(true);
+
+            return bookingEntity;
+        };
+    }
+
+    @Bean
+    public AsyncItemWriter<BookingEntity> usePassesAsyncItemWriter() {
+        AsyncItemWriter<BookingEntity> asyncItemWriter = new AsyncItemWriter<>();
+
+        asyncItemWriter.setDelegate(usePassesItemWriter());
+
+        return asyncItemWriter;
+    }
+
+
+    @Bean
+    public ItemWriter<BookingEntity> usePassesItemWriter() {
+        return bookingEntities -> {
+            for (BookingEntity bookingEntity : bookingEntities) {
+                int updatedCount = passRepository.updateRemainingCount(bookingEntity.getPassSeq(), bookingEntity.getPassEntity().getRemainingCount());
+
+                if (updatedCount > 0) {
+                    bookingRepository.updateUsedPass(bookingEntity.getPassSeq(), bookingEntity.getUsedPass());
+                }
+            }
+        };
+    }
+}

--- a/src/main/java/com/example/pass/repository/booking/BookingEntity.java
+++ b/src/main/java/com/example/pass/repository/booking/BookingEntity.java
@@ -1,5 +1,8 @@
 package com.example.pass.repository.booking;
 
+import com.example.pass.repository.BaseEntity;
+import com.example.pass.repository.pass.PassEntity;
+import com.example.pass.repository.user.UserEntity;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -12,7 +15,7 @@ import java.time.LocalDateTime;
 @ToString
 @Entity
 @Table(name = "booking")
-public class BookingEntity {
+public class BookingEntity extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer bookingSeq;
@@ -33,4 +36,12 @@ public class BookingEntity {
     private LocalDateTime endedAt;
 
     private LocalDateTime cancelledAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId", insertable = false, updatable = false)
+    private UserEntity userEntity;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "passSeq", insertable = false, updatable = false)
+    private PassEntity passEntity;
 }

--- a/src/main/java/com/example/pass/repository/booking/BookingRepository.java
+++ b/src/main/java/com/example/pass/repository/booking/BookingRepository.java
@@ -1,0 +1,17 @@
+package com.example.pass.repository.booking;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+import javax.transaction.Transactional;
+
+public interface BookingRepository extends JpaRepository<BookingEntity, Integer> {
+    @Transactional
+    @Modifying
+    @Query(value = "UPDATE BookingEntity b " +
+                   "   SET b.usedPass = :usedPass, " +
+                   "       b.modifiedAt = CURRENT_TIMESTAMP " +
+                   " WHERE b.passSeq = :passSeq")
+    int updateUsedPass(Integer passSeq, boolean usedPass);
+}

--- a/src/main/java/com/example/pass/repository/booking/BookingStatus.java
+++ b/src/main/java/com/example/pass/repository/booking/BookingStatus.java
@@ -1,4 +1,5 @@
 package com.example.pass.repository.booking;
 
 public enum BookingStatus {
+    COMPLETED
 }

--- a/src/main/java/com/example/pass/repository/pass/PassRepository.java
+++ b/src/main/java/com/example/pass/repository/pass/PassRepository.java
@@ -1,6 +1,18 @@
 package com.example.pass.repository.pass;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+import javax.transaction.Transactional;
 
 public interface PassRepository extends JpaRepository<PassEntity, Integer> {
+
+    @Transactional
+    @Modifying
+    @Query(value = "UPDATE PassEntity p " +
+                   "   SET p.remainingCount = :remainingCount, " +
+                   "       p.modifiedAt = CURRENT_TIMESTAMP " +
+                   "WHERE  p.passSeq = :passSeq")
+    int updateRemainingCount(Integer passSeq, Integer remainingCount);
 }


### PR DESCRIPTION
- 의문 1. 이전 PR에서 CursorItemReader는 Thread un-safe하다고 했는데 이번에는 사용
  - maybe) 이전에는 PagingItemReader를 하면서 동기적으로 데이터를 불러올 수 있도록 순차처리한 반면 이번에는 비동기 박식으로 진행된듯
  - 의문 1-1). 그럼 비동기 작업할 때는 Thread un-safe해도 괜찮은걸까? 모순되지 않았을까?
- 의문 2. 왜 이런 기능에 대한 상세 설명이 누락되어있을까..
- AsyncItemProcessor와 SyncronizedItemProcessor에 대한 추가 정리가 필요 -> 기술블로그에 작성 후 임베드 예정


---
### 필기내용
- AsyncItemProcessor : ItemProcessor에 별도의 Thread가 할당되어 처리하는 방식
  - 복잡한 계산 등으로 인해 ItemProcessor의 작업 수행 시간이 오래걸릴 때, AsyncItemProccessor 및 AsyncItemWriter를 사용하면 성능이 개선된다.
  - 동작 방식
    1. 특정 아이템이 AsyncItemProcessor에 전달될 때 delegate 호출은 새 Thread에서 호출
    2. ItemProcessor의 결과로 반환된 Future는 AsyncItemWriter로 전달됨
    3. AsyncItemWriter는 Future를 처리한 후 결과를 ItemWriter로 전달
    4. ItemWriter에서는 Future 안에 있는 아이템을 꺼내서 일괄 처리
      - Processor에서 작업중인 비동기 실행의 결과값들은 모두 받아올 때까지 대기
    5. AsyncItemProcessor와 AsyncItemWriter를 같이 써야 Future를 처리해줄 수 있다.